### PR TITLE
Correction d'un Maintainers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ License
 Maintainers
 -----------
 
-* Parc National du Haut-Jura
+* Parc Naturel Régional du Haut-Jura
 * Makina Corpus
 
 |logo-pnrhj| |logo-makina|


### PR DESCRIPTION
On parle de Parc Naturel Régional du Haut-Jura et non du Parc National du Jura