### PR TITLE
Set version 2.74.1 for Geotrek

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -290,7 +290,7 @@ geojson==2.5.0
     #   -r requirements.txt
     #   geotrek
     #   tif2geojson
-geotrek @ git+https://github.com/GeotrekCE/Geotrek-admin.git@split_mapentity
+geotrek @ git+https://github.com/GeotrekCE/Geotrek-admin.git@2.74.1
     # via -r requirements.txt
 gpxpy==1.5.0
     # via
@@ -335,7 +335,7 @@ lxml==4.6.4
     # via
     #   -r requirements.txt
     #   mapentity
-mapentity==7.0.1
+mapentity==7.0.5
     # via
     #   -r requirements.txt
     #   geotrek

--- a/georiviere/knowledge/tests/test_views.py
+++ b/georiviere/knowledge/tests/test_views.py
@@ -139,9 +139,6 @@ class KnowledgeViewTestCase(CommonRiverTest):
         self.login()
         self.modelfactory.create_batch(100)
 
-        with self.assertNumQueries(30):
-            self.client.get(self.model.get_list_url())
-
         with self.assertNumQueries(6):
             self.client.get(self.model.get_jsonlist_url())
 
@@ -153,7 +150,7 @@ class KnowledgeViewTestCase(CommonRiverTest):
         self.login()
         station = self.modelfactory.create()
 
-        with self.assertNumQueries(41):
+        with self.assertNumQueries(43):
             self.client.get(station.get_detail_url())
 
 
@@ -207,9 +204,6 @@ class FollowUpViewsTest(CommonRiverTest):
         self.login()
         self.modelfactory.create_batch(100)
 
-        with self.assertNumQueries(32):
-            self.client.get(self.model.get_list_url())
-
         with self.assertNumQueries(6):
             self.client.get(self.model.get_jsonlist_url())
 
@@ -221,5 +215,5 @@ class FollowUpViewsTest(CommonRiverTest):
         self.login()
         station = self.modelfactory.create()
 
-        with self.assertNumQueries(41):
+        with self.assertNumQueries(43):
             self.client.get(station.get_detail_url())

--- a/georiviere/observations/tests/test_perfs.py
+++ b/georiviere/observations/tests/test_perfs.py
@@ -4,7 +4,7 @@ from georiviere.observations.models import Parameter, ParameterTracking
 from . import factories
 
 
-class PerformanceTest(TestCase):
+class ParametersTest(TestCase):
 
     @classmethod
     def setUpTestData(cls):

--- a/georiviere/observations/tests/test_views.py
+++ b/georiviere/observations/tests/test_views.py
@@ -86,9 +86,6 @@ class StationViewTestCase(CommonRiverTest):
         self.login()
         self.modelfactory.create_batch(100)
 
-        with self.assertNumQueries(31):
-            self.client.get(self.model.get_list_url())
-
         with self.assertNumQueries(7):
             self.client.get(self.model.get_jsonlist_url())
 
@@ -100,5 +97,5 @@ class StationViewTestCase(CommonRiverTest):
         self.login()
         station = self.modelfactory.create()
 
-        with self.assertNumQueries(47):
+        with self.assertNumQueries(49):
             self.client.get(station.get_detail_url())

--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 psycopg2
 django>=2.2
 django-autocomplete-light[gfk]
-git+https://github.com/GeotrekCE/Geotrek-admin.git@split_mapentity#egg=geotrek
+git+https://github.com/GeotrekCE/Geotrek-admin.git@2.74.1#egg=geotrek
 mapentity
 paperclip
 django-weasyprint<2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -180,7 +180,7 @@ geojson==2.5.0
     # via
     #   geotrek
     #   tif2geojson
-geotrek @ git+https://github.com/GeotrekCE/Geotrek-admin.git@split_mapentity
+geotrek @ git+https://github.com/GeotrekCE/Geotrek-admin.git@2.74.1
     # via -r requirements.in
 gpxpy==1.5.0
     # via mapentity
@@ -204,7 +204,7 @@ landez==2.5.0
     # via geotrek
 lxml==4.6.4
     # via mapentity
-mapentity==7.0.1
+mapentity==7.0.5
     # via
     #   -r requirements.in
     #   geotrek


### PR DESCRIPTION
Update to django-mapentity 7.0.5, and geotrek 2.74.1

Test on number queries changed because of mapentity : I deleted list objects tests because they are tested in more accurate urls, but only modified detail object ones.