### PR TITLE
🐛 Fix form intervention target

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,8 @@ CHANGELOG
 **Bug fixes**
 
 * Fix all point's marker was showing point to distance
+* Fix form intervention, targets was not save
+
 
 1.0.4        (2023-04-05)
 -------------------------

--- a/georiviere/finances_administration/forms.py
+++ b/georiviere/finances_administration/forms.py
@@ -1,4 +1,4 @@
-from django.forms import inlineformset_factory, Form, ModelForm, DecimalField
+from django.forms import inlineformset_factory, ModelForm, DecimalField
 from django.utils.translation import gettext_lazy as _
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Div, HTML, Layout, Field, Button
@@ -16,16 +16,6 @@ from georiviere.finances_administration.models import (AdministrativeFile,
                                                        AdministrativeOperation,
                                                        AdministrativePhase,
                                                        ManDay)
-
-
-class AdministrativeFileObjectFormMixin(Form):
-    administrative_file = autocomplete.Select2GenericForeignKeyModelField(
-        model_choice=[
-            (AdministrativeFile, 'name',),
-        ],
-        label=_('Create operation on'),
-        required=False
-    )
 
 
 class FundingForm(ModelForm):

--- a/georiviere/knowledge/forms.py
+++ b/georiviere/knowledge/forms.py
@@ -1,4 +1,4 @@
-from django.forms import ModelForm
+from django.forms import ModelForm, ModelChoiceField
 from django.utils.translation import gettext_lazy as _
 
 from crispy_forms.helper import FormHelper
@@ -6,7 +6,7 @@ from crispy_forms.layout import Layout, Div, Fieldset, Field
 from crispy_forms.bootstrap import AppendedText
 from geotrek.common.forms import CommonForm
 
-from georiviere.finances_administration.forms import AdministrativeFileObjectFormMixin
+from georiviere.finances_administration.models import AdministrativeFile
 from georiviere.knowledge.models import Knowledge, Vegetation, Work, FollowUp
 from georiviere.main.widgets import DatePickerInput
 from georiviere.river.fields import SnappedGeometryField
@@ -112,9 +112,11 @@ class WorkForm(ModelForm):
         self.helper.field_class = 'controls col-md-auto'
 
 
-class FollowUpForm(AdministrativeFileObjectFormMixin, CommonForm):
+class FollowUpForm(CommonForm):
     """FollowUp form"""
     _geom = SnappedGeometryField(required=False)
+    administrative_file = ModelChoiceField(label=_("Create operation on"), queryset=AdministrativeFile.objects.all(),
+                                           required=False, initial=None)
 
     geomfields = ['_geom']
 

--- a/georiviere/knowledge/tests/test_views.py
+++ b/georiviere/knowledge/tests/test_views.py
@@ -194,8 +194,7 @@ class FollowUpViewsTest(CommonRiverTest):
     def get_good_data_with_administrative_file(self):
         dict_good_data = deepcopy(self.get_good_data())
         self.administrative_file = AdministrativeFileFactory.create()
-        dict_good_data['administrative_file'] = "{}-{}".format(self.administrative_file.get_content_type_id(),
-                                                               self.administrative_file.pk),
+        dict_good_data['administrative_file'] = self.administrative_file.pk,
         return dict_good_data
 
     def test_good_data_with_administrative_file(self):

--- a/georiviere/maintenance/forms.py
+++ b/georiviere/maintenance/forms.py
@@ -1,3 +1,4 @@
+from django.forms import ModelChoiceField
 from django.utils.translation import gettext_lazy as _
 
 from crispy_forms.layout import Div, Field
@@ -5,14 +6,14 @@ from crispy_forms.bootstrap import AppendedText
 from dal import autocomplete
 from geotrek.common.forms import CommonForm
 
-from georiviere.finances_administration.forms import AdministrativeFileObjectFormMixin
+from georiviere.finances_administration.models import AdministrativeFile
 from georiviere.knowledge.models import Knowledge
 from georiviere.main.widgets import DatePickerInput
 from georiviere.maintenance.models import Intervention
 from georiviere.river.fields import SnappedGeometryField
 
 
-class InterventionForm(AdministrativeFileObjectFormMixin, CommonForm):
+class InterventionForm(autocomplete.FutureModelForm, CommonForm):
     """Intervention form"""
     _geom = SnappedGeometryField(required=False)
 
@@ -26,6 +27,8 @@ class InterventionForm(AdministrativeFileObjectFormMixin, CommonForm):
         required=False,
         initial=None,
     )
+    administrative_file = ModelChoiceField(label=_("Create operation on"), queryset=AdministrativeFile.objects.all(),
+                                           required=False, initial=None)
 
     fieldslayout = [
         Div(

--- a/georiviere/observations/forms.py
+++ b/georiviere/observations/forms.py
@@ -1,12 +1,12 @@
 from django.core.exceptions import ValidationError
-from django.forms import inlineformset_factory, ModelForm
+from django.forms import inlineformset_factory, ModelForm, ModelChoiceField
 from django.utils.translation import gettext_lazy as _
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Div, Field, Fieldset, Layout
 from crispy_forms.bootstrap import Tab, TabHolder
 from geotrek.common.forms import CommonForm
 
-from georiviere.finances_administration.forms import AdministrativeFileObjectFormMixin
+from georiviere.finances_administration.models import AdministrativeFile
 from georiviere.main.widgets import DatePickerInput
 from georiviere.river.fields import SnappedGeometryField
 
@@ -61,9 +61,11 @@ ParameterTrackingFormset = inlineformset_factory(
 )
 
 
-class StationForm(AdministrativeFileObjectFormMixin, CommonForm):
+class StationForm(CommonForm):
     """Station form"""
     geom = SnappedGeometryField()
+    administrative_file = ModelChoiceField(label=_("Create operation on"), queryset=AdministrativeFile.objects.all(),
+                                           required=False, initial=None)
 
     geomfields = ['geom']
 

--- a/georiviere/studies/forms.py
+++ b/georiviere/studies/forms.py
@@ -1,14 +1,19 @@
+from django.forms import ModelChoiceField
+from django.utils.translation import gettext_lazy as _
+
 from crispy_forms.layout import Div, Field
 from geotrek.common.forms import CommonForm
 
-from georiviere.finances_administration.forms import AdministrativeFileObjectFormMixin
+from georiviere.finances_administration.models import AdministrativeFile
 from georiviere.studies.models import Study
 from georiviere.river.fields import SnappedGeometryField
 
 
-class StudyForm(AdministrativeFileObjectFormMixin, CommonForm):
+class StudyForm(CommonForm):
     """Study form"""
     geom = SnappedGeometryField()
+    administrative_file = ModelChoiceField(label=_("Create operation on"), queryset=AdministrativeFile.objects.all(),
+                                           required=False, initial=None)
 
     geomfields = ['geom']
 


### PR DESCRIPTION
This pull request fix a bug which unnallow to save a target on interventions. If we do not use the autocomplete.FutureModelForm, target is not save.
I removed it initially because on administrative file the futuremodelform was not working because the field is not able in the model. and value_from_object need to get the initial values save in the model. 
The only fix i found was this one.
