### PR TITLE
Update CSS of Altimetry

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,11 @@ CHANGELOG
 * Use url lang for sensitivity datas
 
 
+**Enhancement**
+
+- Improve CSS of the altitude profile of altimetry (#210)
+
+
 1.2.2        (2023-08-09)
 -------------------------
 

--- a/georiviere/river/static/river/css/style.css
+++ b/georiviere/river/static/river/css/style.css
@@ -15,10 +15,12 @@
     background-size: 15px;
 }
 
+/* To remove when Geotrek is updated to 2.100.0 */
 #altitudegraph.colapsed {
     width: revert !important;
 }
 
+/* To remove when Geotrek is updated to 2.100.0 */
 #altitudegraph {
     bottom: 24px !important;
     right: 14px !important;

--- a/georiviere/river/static/river/css/style.css
+++ b/georiviere/river/static/river/css/style.css
@@ -14,3 +14,12 @@
     background-position: 5px 5px, center;
     background-size: 15px;
 }
+
+#altitudegraph.colapsed {
+    width: revert !important;
+}
+
+#altitudegraph {
+    bottom: 24px !important;
+    right: 14px !important;
+}


### PR DESCRIPTION
This pull request changes how altitude profiles look. Right now, they look like this:

![OLD_ALTIMETRY_GEOR](https://github.com/Georiviere/Georiviere-admin/assets/92665273/a8841283-2ae2-432c-a38c-dfa00988de3e)

![OLD_ALTIMETRY_GEOR2](https://github.com/Georiviere/Georiviere-admin/assets/92665273/6df8a218-9b96-4148-a4ec-80518654bd2f)

After this change, they will look like this:

![NEW_ALTIMETRY_GEOR](https://github.com/Georiviere/Georiviere-admin/assets/92665273/b7da7e36-362f-4ad6-8ca3-a9c39dbf8e49)

![NEW_ALTIMETRY_GEOR2](https://github.com/Georiviere/Georiviere-admin/assets/92665273/2c32dbce-52dc-488f-8644-00b46fe1cd75)

As a result, the altitude profile will show higher up on the page, which let some space for the attribution mark.
