### PR TITLE
Fix signals and type usage in portal creation

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ CHANGELOG
 **Bug fix**
 
 - Force translation defined in API url /api/portal/<lang> (fix #222)
+- Revert type translation cause bug in portal creation
 
 **Enhancement**
 

--- a/georiviere/portal/signals.py
+++ b/georiviere/portal/signals.py
@@ -30,15 +30,15 @@ def save_portal(sender, instance, created, **kwargs):
         MapBaseLayer.objects.create(label='OSM', order=0, url='https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
                                     attribution='© Contributeurs OpenStreetMap', portal=instance)
         # Generate all layers
-        MapLayer.objects.create(label=_('Watershed'), order=0, layer_type=_('watersheds'), portal=instance)
-        MapLayer.objects.create(label=_('City'), order=0, layer_type=_('cities'), portal=instance)
-        MapLayer.objects.create(label=_('Sensitivity'), order=0, layer_type=_('sensitivities'), portal=instance)
-        MapLayer.objects.create(label=_('District'), order=0, layer_type=_('districts'), portal=instance)
-        MapLayer.objects.create(label=_('Contribution'), order=0, layer_type=_('contributions'), portal=instance)
+        MapLayer.objects.create(label=_('Watershed'), order=0, layer_type='watersheds', portal=instance)
+        MapLayer.objects.create(label=_('City'), order=0, layer_type='cities', portal=instance)
+        MapLayer.objects.create(label=_('Sensitivity'), order=0, layer_type='sensitivities', portal=instance)
+        MapLayer.objects.create(label=_('District'), order=0, layer_type='districts', portal=instance)
+        MapLayer.objects.create(label=_('Contribution'), order=0, layer_type='contributions', portal=instance)
         # We generate a map layer for each category of poi with the layer type separated by a -
         # We use it after in the serializer / view to generate a geojson url for each of them
         for category in POICategory.objects.all():
             MapLayer.objects.create(label=f'{category.label}', order=0, layer_type=f'pois-{category.pk}',
                                     portal=instance)
 
-        MapLayer.objects.create(label=_('Stream'), order=0, layer_type=_('streams'), portal=instance)
+        MapLayer.objects.create(label=_('Stream'), order=0, layer_type='streams', portal=instance)


### PR DESCRIPTION
Creating portal with type translated cause bug at runtime because associted endpoint are not translated