### PR TITLE
Fix: Drop function 'update_topologies' before creating it again to prevent error message during update and failures with altimetry

### DIFF
--- a/georiviere/river/sql/pre_10_cleanup.sql
+++ b/georiviere/river/sql/pre_10_cleanup.sql
@@ -1,3 +1,3 @@
 DROP FUNCTION IF EXISTS update_topology_geom() CASCADE;
+DROP FUNCTION IF EXISTS update_topologies() CASCADE;
 DROP FUNCTION IF EXISTS create_topologies() CASCADE;
-


### PR DESCRIPTION
Without this fix : 
- Error message during update : `Failed to install custom SQL file '/opt/georiviere-admin/georiviere/river/sql/post_10_triggers.sql': function "update_topologies" already exists with same argument types`
- When trying to install a DEM or create a stream, neither length or altimetry were computed